### PR TITLE
Fixes For General Warning & Notice

### DIFF
--- a/src/Pseudo/Pdo.php
+++ b/src/Pseudo/Pdo.php
@@ -7,7 +7,7 @@ class Pdo extends \PDO
     private $inTransaction = false;
     private $queryLog;
 
-    public function prepare($statement, array $driver_options = [])
+    public function prepare($statement, $driver_options = [])
     {
         $result = $this->mockedQueries->getResult($statement);
         $statement = new PdoStatement($result);

--- a/src/Pseudo/PdoStatement.php
+++ b/src/Pseudo/PdoStatement.php
@@ -29,7 +29,7 @@ class PdoStatement extends \PDOStatement
      * @param array|null $input_parameters
      * @return bool
      */
-    public function execute(array $input_parameters = null)
+    public function execute($input_parameters = null)
     {
         try {
             $success = (bool) $this->result->getRows($input_parameters ?: []);
@@ -94,6 +94,7 @@ class PdoStatement extends \PDOStatement
 
     private function proccessFetchedRow($row, $fetchMode)
     {
+		$i = 0;
         switch ($fetchMode ?: $this->fetchMode) {
             case \PDO::FETCH_BOTH:
                 $returnRow = [];
@@ -140,7 +141,7 @@ class PdoStatement extends \PDOStatement
      * @param array|null $ctor_args
      * @return bool|mixed
      */
-    public function fetchObject($class_name = "stdClass", array $ctor_args = null)
+    public function fetchObject($class_name = "stdClass", $ctor_args = null)
     {
         $row = $this->result->nextRow();
         if ($row) {

--- a/src/Pseudo/Result.php
+++ b/src/Pseudo/Result.php
@@ -56,7 +56,7 @@ class Result
      */
     public function nextRow()
     {
-        $row = $this->rows[$this->rowOffset];
+        $row = (isset($this->rows[$this->rowOffset])) ? $this->rows[$this->rowOffset] : null;
         if ($row) {
             $this->rowOffset++;
             return $row;

--- a/src/Pseudo/ResultCollection.php
+++ b/src/Pseudo/ResultCollection.php
@@ -36,7 +36,7 @@ class ResultCollection implements \Countable
         if (!($query instanceof ParsedQuery)) {
             $query = new ParsedQuery($query);
         }
-        $result = $this->queries[$query->getHash()];
+        $result = (isset($this->queries[$query->getHash()])) ? $this->queries[$query->getHash()] : null;
         if ($result instanceof Result) {
             return $result;
         } else {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <phpunit>
-    <php>
-        <ini name="error_reporting" value="E_ALL &amp; ~(E_NOTICE | E_DEPRECATED | E_STRICT)"/>
-    </php>
     <testsuite>
         <directory suffix="Test.php">.</directory>
     </testsuite>


### PR DESCRIPTION
- method signatures match actual PHP unit signatures
- removed ini setting of non-strict error reporting mode