### PR TITLE
Bugfix : error for parameterized queries which returned empty results

### DIFF
--- a/src/Pseudo/Result.php
+++ b/src/Pseudo/Result.php
@@ -59,22 +59,39 @@ class Result
     }
 
     /**
+     * Returns the next row if it exists, otherwise returns false
+     *
+     * @param   array   $rows   Rows to get row from
+     * @return  array           Next row (false if doesn't exist)
+     */ 
+    private function getRowIfExists(array $rows)
+    {
+        if (empty($rows[$this->rowOffset])) {
+            return false;
+        }
+        return $rows[$this->rowOffset];
+    }
+
+    /**
+     * Returns the next available row if it exists, otherwise returns false
+     *
      * @return array
      */
     public function nextRow()
     {
         if ($this->isParameterized) {
-            $row = $this->rows[$this->stringifyParameterSet($this->params)][$this->rowOffset];
+            $row = $this->getRowIfExists($this->rows[$this->stringifyParameterSet($this->params)]);
         } else {
-            $row = (isset($this->rows[$this->rowOffset])) ? $this->rows[$this->rowOffset] : null;
+            $row = $this->getRowIfExists($this->rows);
         }
+
         if ($row) {
             $this->rowOffset++;
-            return $row;
-        } else {
-            return false;
         }
+
+        return $row;
     }
+
 
     public function setInsertId($insertId)
     {

--- a/src/Pseudo/Result.php
+++ b/src/Pseudo/Result.php
@@ -64,9 +64,9 @@ class Result
      * @param   array   $rows   Rows to get row from
      * @return  array           Next row (false if doesn't exist)
      */ 
-    private function getRowIfExists(array $rows)
+    private function getRowIfExists($rows)
     {
-        if (empty($rows[$this->rowOffset])) {
+        if (!isset($rows[$this->rowOffset])) {
             return false;
         }
         return $rows[$this->rowOffset];


### PR DESCRIPTION
The code for dealing with parameterized and non-parameterized queries in the Result class was marginally different, which meant that when you tried to do a parameterized query that returned no rows, the rowOffset was misfiring and causing errors.  This fixes that problem :)

Thanks by the way, this library/code/whatever is dead useful!