### PR TITLE
feat: debugging raw queries alognside with the un-mocked exception

### DIFF
--- a/src/Pseudo/ParsedQuery.php
+++ b/src/Pseudo/ParsedQuery.php
@@ -34,5 +34,11 @@ class ParsedQuery
         return $this->hash;
     }
 
-
+    /**
+     * @return string
+     */
+    public function getRawQuery()
+    {
+        return $this->rawQuery;
+    }
 }

--- a/src/Pseudo/Pdo.php
+++ b/src/Pseudo/Pdo.php
@@ -77,7 +77,7 @@ class Pdo extends \PDO
                 return $statement;
             }
         } else {
-
+            
         }
     }
 
@@ -126,10 +126,11 @@ class Pdo extends \PDO
 
     /**
      * @param ResultCollection $collection
+     * @param array            $options    Holds configuration for a result collection.
      */
-    public function __construct(ResultCollection $collection = null)
+    public function __construct(ResultCollection $collection = null, array $options = []) 
     {
-        $this->mockedQueries = $collection ?: new ResultCollection();
+        $this->mockedQueries = $collection ?: new ResultCollection($options);
         $this->queryLog = new QueryLog();
     }
 

--- a/src/Pseudo/Pdo.php
+++ b/src/Pseudo/Pdo.php
@@ -126,11 +126,10 @@ class Pdo extends \PDO
 
     /**
      * @param ResultCollection $collection
-     * @param array            $options    Holds configuration for a result collection.
      */
-    public function __construct(ResultCollection $collection = null, array $options = []) 
+    public function __construct(ResultCollection $collection = null) 
     {
-        $this->mockedQueries = $collection ?: new ResultCollection($options);
+        $this->mockedQueries = $collection ?: new ResultCollection();
         $this->queryLog = new QueryLog();
     }
 

--- a/src/Pseudo/ResultCollection.php
+++ b/src/Pseudo/ResultCollection.php
@@ -4,6 +4,23 @@ namespace Pseudo;
 class ResultCollection implements \Countable
 {
     private $queries = [];
+    /**
+     * Holds configuration settings for an object.
+     * Defining the field options:
+     * array['sqlDebug'] boolean Display the raw query alongside the un-mocked query exception (default `true`).
+     * @var array (See above)
+     */
+    private $options = [
+        'sqlDebug' => false
+    ];
+    
+    /**
+     * @param array $options Holds configuration, see the property description.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = array_replace_recursive($this->options, $options);
+    }
 
     public function count()
     {
@@ -40,7 +57,11 @@ class ResultCollection implements \Countable
         if ($result instanceof Result) {
             return $result;
         } else {
-            throw new Exception("Attempting an operation on an un-mocked query is not allowed");
+            $message = "Attempting an operation on an un-mocked query is not allowed";
+            if ($this->options['sqlDebug']) {
+                $message .= ', the raw query: ' . $query->getRawQuery();
+            }
+            throw new Exception($message);
         }
     }
 }

--- a/src/Pseudo/ResultCollection.php
+++ b/src/Pseudo/ResultCollection.php
@@ -4,24 +4,7 @@ namespace Pseudo;
 class ResultCollection implements \Countable
 {
     private $queries = [];
-    /**
-     * Holds configuration settings for an object.
-     * Defining the field options:
-     * array['sqlDebug'] boolean Display the raw query alongside the un-mocked query exception (default `true`).
-     * @var array (See above)
-     */
-    private $options = [
-        'sqlDebug' => false
-    ];
     
-    /**
-     * @param array $options Holds configuration, see the property description.
-     */
-    public function __construct(array $options = [])
-    {
-        $this->options = array_replace_recursive($this->options, $options);
-    }
-
     public function count()
     {
         return count($this->queries);
@@ -57,10 +40,8 @@ class ResultCollection implements \Countable
         if ($result instanceof Result) {
             return $result;
         } else {
-            $message = "Attempting an operation on an un-mocked query is not allowed";
-            if ($this->options['sqlDebug']) {
-                $message .= ', the raw query: ' . $query->getRawQuery();
-            }
+            $message = "Attempting an operation on an un-mocked query is not allowed, the raw query: "
+                . $query->getRawQuery();
             throw new Exception($message);
         }
     }

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -162,4 +162,17 @@ class PdoTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($r, $queries);
         unlink('testsave');
     }
+    
+    public function testDebuggingRawQueries()
+    {
+        
+        $message = null;
+        $p = new Pseudo\Pdo(null, ['sqlDebug' => true]);
+        try {
+            $p->prepare('SELECT 123');
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+        $this->assertRegExp('/SELECT 123/', $message);
+    }
 }

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -167,7 +167,7 @@ class PdoTest extends PHPUnit_Framework_TestCase
     {
         
         $message = null;
-        $p = new Pseudo\Pdo(null, ['sqlDebug' => true]);
+        $p = new Pseudo\Pdo();
         try {
             $p->prepare('SELECT 123');
         } catch (Exception $e) {

--- a/tests/ResultCollectionTest.php
+++ b/tests/ResultCollectionTest.php
@@ -7,4 +7,16 @@ class ResultCollectionTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException("Pseudo\\Exception");
         $r->getResult("SELECT 1");
     }
+    
+    public function testDebuggingRawQueries()
+    {
+        $message = null;
+        $r = new Pseudo\ResultCollection(['sqlDebug' => true]);
+        try {
+            $r->getResult('SELECT 123');
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+        $this->assertRegExp('/SELECT 123/', $message);
+    }
 }

--- a/tests/ResultCollectionTest.php
+++ b/tests/ResultCollectionTest.php
@@ -11,7 +11,7 @@ class ResultCollectionTest extends PHPUnit_Framework_TestCase
     public function testDebuggingRawQueries()
     {
         $message = null;
-        $r = new Pseudo\ResultCollection(['sqlDebug' => true]);
+        $r = new Pseudo\ResultCollection();
         try {
             $r->getResult('SELECT 123');
         } catch (Exception $e) {


### PR DESCRIPTION
I've added the feature of displaying raw queries alongside with the un-mocked query exceptions. This is helpful for creating tests for existing code when many queries can be un-mocked and it is hard to identify them.