### PR TITLE
Changed continue to continue 2 to stop PHP warnings

### DIFF
--- a/src/php-sql-parser.php
+++ b/src/php-sql-parser.php
@@ -1174,7 +1174,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
                     }
                     $parseInfo['alias']['name'] = $str;
                     $parseInfo['alias']['base_expr'] = trim($parseInfo['alias']['base_expr']);
-                    continue;
+                    continue 2;
 
                 case 'INDEX':
                     if ($token_category == 'CREATE') {
@@ -1196,13 +1196,13 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
                 case 'INNER':
                 case 'OUTER':
                     $parseInfo['token_count']++;
-                    continue;
+                    continue 2;
                     break;
 
                 case 'FOR':
                     $parseInfo['token_count']++;
                     $skip_next = true;
-                    continue;
+                    continue 2;
                     break;
 
                 case 'LEFT':
@@ -1226,7 +1226,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
 
                 default:
                     if ($upper === "") {
-                        continue; # ends the switch statement!
+                        continue 2; # ends the switch statement!
                     }
 
                     if ($parseInfo['token_count'] === 0) {


### PR DESCRIPTION
Stops PHP 7.3 and up complaining about the use of _continue_ in these _switch_ cases. Doesn't affect functionality as the _switch_ is only in one _for_ loop.