### PR TITLE
Refactored to use parameters in determining result sets for queries

### DIFF
--- a/src/Pseudo/ParsedQuery.php
+++ b/src/Pseudo/ParsedQuery.php
@@ -6,22 +6,28 @@ class ParsedQuery
     private $parsedQuery;
     private $rawQuery;
     private $hash;
+    private $params;
 
     /**
      * @param string $query
      */
-    public function __construct($query)
+    public function __construct($query, $params = null)
     {
         $parser = new \PHPSQLParser();
         $this->parsedQuery = $parser->parse($query);
         $this->rawQuery = $query;
-        $this->hash = sha1(serialize($this->parsedQuery));
+        $this->params = $params;
+        $serializedParams = "";
+        if ($this->params != null) {
+          $serializedParams = serialize($this->params);
+        }
+        $this->hash = sha1(serialize($this->parsedQuery) . $serializedParams);
     }
 
-    public function isEqualTo($query)
+    public function isEqualTo($query, $params = null)
     {
         if (!($query instanceof self)) {
-            $query = new self($query);
+            $query = new self($query, $params);
         }
         return $this->hash === $query->getHash();
     }

--- a/src/Pseudo/Pdo.php
+++ b/src/Pseudo/Pdo.php
@@ -9,8 +9,7 @@ class Pdo extends \PDO
 
     public function prepare($statement, $driver_options = null)
     {
-        $result = $this->mockedQueries->getResult($statement);
-        return new PdoStatement($result, $this->queryLog, $statement);
+        return new PdoStatement($this->mockedQueries, $this->queryLog, $statement);
     }
 
     public function beginTransaction()
@@ -71,7 +70,7 @@ class Pdo extends \PDO
             $result = $this->mockedQueries->getResult($statement);
             if ($result) {
                 $this->queryLog->addQuery($statement);
-                $statement = new PdoStatement();
+                $statement = new PdoStatement($this->mockedQueries);
                 $statement->setResult($result);
                 return $statement;
             }
@@ -124,7 +123,7 @@ class Pdo extends \PDO
     /**
      * @param ResultCollection $collection
      */
-    public function __construct(ResultCollection $collection = null) 
+    public function __construct(ResultCollection $collection = null)
     {
         $this->mockedQueries = $collection ?: new ResultCollection();
         $this->queryLog = new QueryLog();

--- a/src/Pseudo/PdoStatement.php
+++ b/src/Pseudo/PdoStatement.php
@@ -7,6 +7,7 @@ class PdoStatement extends \PDOStatement
     /**
      * @var Result;
      */
+    private $mockedQueries;
     private $result;
     private $fetchMode = \PDO::FETCH_BOTH; //DEFAULT FETCHMODE
     private $boundParams = [];
@@ -27,12 +28,9 @@ class PdoStatement extends \PDOStatement
      * @param string $statement
      * @param Result|null $result
      */
-    public function __construct($result = null, QueryLog $queryLog = null, $statement = null)
+    public function __construct($mockedQueries = null, QueryLog $queryLog = null, $statement = null)
     {
-        if (!($result instanceof Result)) {
-            $result = new Result();
-        }
-        $this->result = $result;
+        $this->mockedQueries = $mockedQueries;
         if (!($queryLog instanceof QueryLog)) {
             $queryLog = new QueryLog();
         }
@@ -52,6 +50,7 @@ class PdoStatement extends \PDOStatement
     public function execute($input_parameters = null)
     {
         $input_parameters = array_merge((array)$input_parameters, $this->boundParams);
+        $this->result = $this->mockedQueries->getResult($this->statement, $input_parameters);
         try {
             $this->result->setParams($input_parameters, !empty($this->boundParams));
             $success = (bool) $this->result->getRows($input_parameters ?: []);
@@ -62,7 +61,7 @@ class PdoStatement extends \PDOStatement
         }
     }
 
-    public function fetch($fetch_style = null, $cursor_orientation = PDO::FETCH_ORI_NEXT, $cursor_offset = 0)
+    public function fetch($fetch_style = null, $cursor_orientation = \PDO::FETCH_ORI_NEXT, $cursor_offset = 0)
     {
         // scrolling cursors not implemented
         $row = $this->result->nextRow();

--- a/src/Pseudo/QueryLog.php
+++ b/src/Pseudo/QueryLog.php
@@ -35,9 +35,9 @@ class QueryLog implements \IteratorAggregate, \ArrayAccess, \Countable
         unset($this->queries[$offset]);
     }
 
-    public function addQuery($sql)
+    public function addQuery($sql, $params = null)
     {
-        $this->queries[] = new ParsedQuery($sql);
+        $this->queries[] = new ParsedQuery($sql, $params);
     }
 
     public function getQueries()

--- a/src/Pseudo/ResultCollection.php
+++ b/src/Pseudo/ResultCollection.php
@@ -4,7 +4,7 @@ namespace Pseudo;
 class ResultCollection implements \Countable
 {
     private $queries = [];
-    
+
     public function count()
     {
         return count($this->queries);
@@ -12,7 +12,7 @@ class ResultCollection implements \Countable
 
     public function addQuery($sql, $results, $params = null)
     {
-        $query = new ParsedQuery($sql);
+        $query = new ParsedQuery($sql, $params);
 
         if (is_array($results)) {
             $storedResults = new Result($results, $params);
@@ -25,16 +25,16 @@ class ResultCollection implements \Countable
         $this->queries[$query->getHash()] = $storedResults;
     }
 
-    public function exists($sql)
+    public function exists($sql, $params = null)
     {
-        $query = new ParsedQuery($sql);
+        $query = new ParsedQuery($sql, $params);
         return isset($this->queries[$query->getHash()]);
     }
 
-    public function getResult($query)
+    public function getResult($query, $params = null)
     {
         if (!($query instanceof ParsedQuery)) {
-            $query = new ParsedQuery($query);
+            $query = new ParsedQuery($query, $params);
         }
         $result = (isset($this->queries[$query->getHash()])) ? $this->queries[$query->getHash()] : null;
         if ($result instanceof Result) {

--- a/tests/ParsedQueryTest.php
+++ b/tests/ParsedQueryTest.php
@@ -11,6 +11,17 @@ class ParsedQueryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($hashed, $q->getHash());
     }
 
+    public function testQueryHashingWithParams()
+    {
+        $sql = "SELECT foo FROM bar WHERE baz = ?";
+        $params = ["foo"];
+        $q = new \Pseudo\ParsedQuery($sql, $params);
+        $p = new \PHPSQLParser();
+        $parsed = $p->parse($sql);
+        $hashed = sha1(serialize($parsed) . serialize($params));
+        $this->assertEquals($hashed, $q->getHash());
+    }
+
     public function testIsEquals()
     {
         $sql = "SELECT foo FROM bar WHERE baz";

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -34,7 +34,7 @@ class PdoTest extends PHPUnit_Framework_TestCase
         $p->mock($sql3, $result1, $params3);
         $p->mock($sql3, $result2, $params4);
 
-        $this->assertEquals(3, count($p->getMockedQueries()));
+        $this->assertEquals(4, count($p->getMockedQueries()));
 
 
     }
@@ -174,13 +174,14 @@ class PdoTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($r, $queries);
         unlink('testsave');
     }
-    
+
     public function testDebuggingRawQueries()
     {
         $message = null;
         $p = new Pseudo\Pdo();
         try {
-            $p->prepare('SELECT 123');
+            $sth = $p->prepare('SELECT 123');
+            $sth->execute();
         } catch (Exception $e) {
             $message = $e->getMessage();
         }

--- a/tests/QueryLogTest.php
+++ b/tests/QueryLogTest.php
@@ -10,4 +10,15 @@ class QueryLogTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($queries));
         $this->assertTrue($queries[0]->isEqualTo($sql));
     }
+
+    public function testAddQueryWithParams()
+    {
+        $sql = "SELECT foo FROM ?";
+        $params = ["bar"];
+        $queryLog = new \Pseudo\QueryLog();
+        $queryLog->addQuery($sql, $params);
+        $queries = $queryLog->getQueries();
+        $this->assertEquals(1, count($queries));
+        $this->assertTrue($queries[0]->isEqualTo($sql, $params));
+    }
 }


### PR DESCRIPTION
I refactored the way result sets are pulled as I need to be able to do this:

```
    $pdo->mock("select * from My_Table where UID = ?", [["UID" => "ABC", "NAME" => "A"]], ["ABC"]);
    $pdo->mock("select * from My_Table where UID = ?", [["UID" => "DEF", "NAME" => "B"]], ["DEF"]);
```
