### PR TITLE
Fix for PHP 7.4: Trying to access array offset on value of type null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 script:
   - composer install --dev && vendor/bin/phpunit

--- a/src/php-sql-parser.php
+++ b/src/php-sql-parser.php
@@ -221,7 +221,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
     /**
      * This class splits the SQL string into little parts, which the parser can
      * use to build the result array.
-     * 
+     *
      * @author arothe
      *
      */
@@ -320,7 +320,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
         /*
          * does the token ends with dot?
          * concat it with the next token
-         * 
+         *
          * does the token starts with a dot?
          * concat it with the previous token
          */
@@ -962,7 +962,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
         private function process_limit($tokens) {
             $rowcount = "";
             $offset = "";
-            
+
             $comma = -1;
             $exchange = false;
 
@@ -994,14 +994,14 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
                     $rowcount .= $tokens[$i];
                 }
             }
-            
+
             return array('offset' => trim($offset), 'rowcount' => trim($rowcount));
         }
 
         /* This function processes the SELECT section.  It splits the clauses at the commas.
          Each clause is then processed by process_select_expr() and the results are added to
          the expression list.
-        
+
          Finally, at the end, the epxression list is returned.
          */
         private function process_select(&$tokens) {
@@ -1555,7 +1555,7 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
                         # last token is colref, const or expression
                         # it is an operator, in all other cases it is an all-columns-alias
                         # if the previous colref ends with a dot, the * is the all-columns-alias
-                        if (!is_array($parseInfo['expr'])) {
+                        if (!$parseInfo['expr'] || !is_array($parseInfo['expr'])) {
                             $parseInfo['tokenType'] = "colref"; # single or first element of select -> *
                             break;
                         }
@@ -1826,12 +1826,12 @@ if (!defined('HAVE_PHP_SQL_PARSER')) {
     }
 
     /**
-     * 
-     * This class calculates the positions 
+     *
+     * This class calculates the positions
      * of base_expr within the origina SQL statement.
-     * 
+     *
      * @author arothe
-     * 
+     *
      */
     class PositionCalculator extends PHPSQLParserUtils {
 


### PR DESCRIPTION
PHP 7.4 disallows accessing an array key on a NULL value. This PR prevents the from getting to the point where it tries to access an array index on a NULL value. 

Additionally, added targets for PHP 7.3 and 7.4 in `.travis.yml`.

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

...............E...EE.E....E..........                            38 / 38 (100%)

Time: 43 ms, Memory: 4.00MB

There were 5 errors:

1) PdoStatementTest::testExecute
Trying to access array offset on value of type null

./pseudo/src/php-sql-parser.php:1564
./pseudo/src/php-sql-parser.php:1075
./pseudo/src/php-sql-parser.php:1019
./pseudo/src/php-sql-parser.php:876
./pseudo/src/php-sql-parser.php:868
./pseudo/src/php-sql-parser.php:454
./pseudo/src/Pseudo/ParsedQuery.php:16
./pseudo/src/Pseudo/QueryLog.php:40
./pseudo/src/Pseudo/PdoStatement.php:58
./pseudo/tests/PdoStatementTest.php:224

2) PdoTest::testMock
Trying to access array offset on value of type null

./pseudo/src/php-sql-parser.php:1564
./pseudo/src/php-sql-parser.php:1075
./pseudo/src/php-sql-parser.php:1019
./pseudo/src/php-sql-parser.php:876
./pseudo/src/php-sql-parser.php:868
./pseudo/src/php-sql-parser.php:454
./pseudo/src/Pseudo/ParsedQuery.php:16
./pseudo/src/Pseudo/ResultCollection.php:15
./pseudo/src/Pseudo/Pdo.php:156
./pseudo/tests/PdoTest.php:15

3) PdoTest::testQueryReturnsMockedResults
Trying to access array offset on value of type null

./pseudo/src/php-sql-parser.php:1564
./pseudo/src/php-sql-parser.php:1075
./pseudo/src/php-sql-parser.php:1019
./pseudo/src/php-sql-parser.php:876
./pseudo/src/php-sql-parser.php:868
./pseudo/src/php-sql-parser.php:454
./pseudo/src/Pseudo/ParsedQuery.php:16
./pseudo/src/Pseudo/ResultCollection.php:15
./pseudo/src/Pseudo/Pdo.php:156
./pseudo/tests/PdoTest.php:53

4) PdoTest::testLastInsertIdPreparedStatement
Trying to access array offset on value of type null

./pseudo/src/php-sql-parser.php:1564
./pseudo/src/php-sql-parser.php:1075
./pseudo/src/php-sql-parser.php:1019
./pseudo/src/php-sql-parser.php:876
./pseudo/src/php-sql-parser.php:868
./pseudo/src/php-sql-parser.php:454
./pseudo/src/Pseudo/ParsedQuery.php:16
./pseudo/src/Pseudo/ResultCollection.php:15
./pseudo/src/Pseudo/Pdo.php:156
./pseudo/tests/PdoTest.php:77

5) PdoTest::testPrepare
Trying to access array offset on value of type null

./pseudo/src/php-sql-parser.php:1564
./pseudo/src/php-sql-parser.php:1075
./pseudo/src/php-sql-parser.php:1019
./pseudo/src/php-sql-parser.php:876
./pseudo/src/php-sql-parser.php:868
./pseudo/src/php-sql-parser.php:454
./pseudo/src/Pseudo/ParsedQuery.php:16
./pseudo/src/Pseudo/ResultCollection.php:15
./pseudo/src/Pseudo/Pdo.php:156
./pseudo/tests/PdoTest.php:143

ERRORS!
Tests: 38, Assertions: 63, Errors: 5.
```