### PR TITLE
PHP8 signature compatibility upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 script:
   - composer install --dev && vendor/bin/phpunit

--- a/src/Pseudo/Pdo.php
+++ b/src/Pseudo/Pdo.php
@@ -62,15 +62,17 @@ class Pdo extends \PDO
     }
 
     /**
-     * @param string $statement
+     * @param string $query
+     * @param int|null $fetchMode
+     * @param mixed ...$fetchModeArgs
      * @return PdoStatement
      */
-    public function query($statement)
+    public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs)
     {
-        if ($this->mockedQueries->exists($statement)) {
-            $result = $this->mockedQueries->getResult($statement);
+        if ($this->mockedQueries->exists($query)) {
+            $result = $this->mockedQueries->getResult($query);
             if ($result) {
-                $this->queryLog->addQuery($statement);
+                $this->queryLog->addQuery($query);
                 $statement = new PdoStatement();
                 $statement->setResult($result);
                 return $statement;

--- a/src/Pseudo/PdoStatement.php
+++ b/src/Pseudo/PdoStatement.php
@@ -105,19 +105,19 @@ class PdoStatement extends \PDOStatement
         return false;
     }
 
-    public function fetchAll($fetch_style = \PDO::FETCH_BOTH, $fetch_argument = null, $ctor_args = 'array()')
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args)
     {
         $rows = $this->result->getRows() ?: [];
         $returnArray = [];
         foreach ($rows as $row) {
-            $returnArray[] = $this->proccessFetchedRow($row, $fetch_style);
+            $returnArray[] = $this->proccessFetchedRow($row, $mode);
         }
         return $returnArray;
     }
 
     private function proccessFetchedRow($row, $fetchMode)
     {
-		$i = 0;
+        $i = 0;
         switch ($fetchMode ?: $this->fetchMode) {
             case \PDO::FETCH_BOTH:
                 $returnRow = [];
@@ -206,10 +206,10 @@ class PdoStatement extends \PDOStatement
 
     /**
      * @param int $mode
-     * @param array|null $params
+     * @param mixed ...$args
      * @return bool|int
      */
-    public function setFetchMode($mode, $params = null)
+    public function setFetchMode(int $mode, mixed ...$args)
     {
         $r = new \ReflectionClass(new Pdo());
         $constants = $r->getConstants();


### PR DESCRIPTION
The Pdo and PdoStatement classes needed an update on the parameters for a couple of methods, in order to match the signature from the base PDO classes. 

Prior to these changes, you would see the following errors:

```
PHP Fatal error:  Declaration of Pseudo\Pdo::query($statement) must be compatible with PDO::query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs) in /app/vendor/jimbojsb/pseudo/src/Pseudo/Pdo.php on line 68
```

```
PHP Fatal error:  Declaration of Pseudo\PdoStatement::fetchAll($fetch_style = PDO::FETCH_BOTH, $fetch_argument = null, $ctor_args = 'array()') must be compatible with PDOStatement::fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args) in /app/vendor/jimbojsb/pseudo/src/Pseudo/PdoStatement.php on line 108
```

```
PHP Fatal error:  Declaration of Pseudo\PdoStatement::setFetchMode($mode, $params = null) must be compatible with PDOStatement::setFetchMode(int $mode, mixed ...$args) in /app/vendor/jimbojsb/pseudo/src/Pseudo/PdoStatement.php on line 212
```